### PR TITLE
URL ID filter, error logging, and API key redaction

### DIFF
--- a/AlmaApi.lua
+++ b/AlmaApi.lua
@@ -15,6 +15,12 @@ local log = types["log4net.LogManager"].GetLogger(rootLogger .. ".AlmaApi");
 
 AlmaApi = AlmaApiInternal;
 
+local function Initialize(apiUrl, apiKey)
+    AlmaApiInternal.ApiUrl = apiUrl;
+    AlmaApiInternal.ApiKey = apiKey;
+    WebClient.Initialize(apiKey);
+end
+
 local function RetrieveHoldingsList( mmsId )
     local requestUrl = AlmaApiInternal.ApiUrl .."bibs/"..
         Utility.URLEncode(mmsId) .."/holdings?apikey=" .. Utility.URLEncode(AlmaApiInternal.ApiKey);
@@ -50,10 +56,15 @@ end
 local function RetrieveItemsList(mmsId, holdingId)
 	local xmlResult, itemsNode;
 	local offset, totalItems = 0, 0;
-	
+
 	repeat
 		local xmlSubresult = RetrieveItemsSublist(mmsId, holdingId, offset);
-		
+
+		if xmlSubresult == nil then
+			log:WarnFormat("No items response for MMS ID {0}, Holding ID {1} (offset {2}).", mmsId, holdingId, offset);
+			return xmlResult;
+		end
+
 		if (xmlResult == nil) then
 			xmlResult = xmlSubresult;
 			itemsNode = xmlResult:SelectSingleNode("/items");
@@ -62,15 +73,15 @@ local function RetrieveItemsList(mmsId, holdingId)
 		else
 			--Merge the next subset results with the working list
 			local itemNodes = xmlSubresult:SelectNodes("/items/item");
-			
+
 			for i = 0, itemNodes.Count - 1 do
-				local nodeCopy = xmlResult:ImportNode(itemNodes:Item(i), true); 
+				local nodeCopy = xmlResult:ImportNode(itemNodes:Item(i), true);
 				itemsNode:AppendChild(nodeCopy);
 			end
 		end
-		
+
 		offset = offset + 100;
-	
+
 	until totalItems <= offset;
 
 	return xmlResult;
@@ -88,6 +99,7 @@ local function RetrieveHoldingsRecordInfo(mmsId, holdingId)
 end
 
 -- Exports
+AlmaApi.Initialize = Initialize;
 AlmaApi.RetrieveHoldingsList = RetrieveHoldingsList;
 AlmaApi.RetrieveBibs = RetrieveBibs;
 AlmaApi.RetrieveItemsList = RetrieveItemsList;

--- a/AlmaApi.lua
+++ b/AlmaApi.lua
@@ -61,7 +61,15 @@ local function RetrieveItemsList(mmsId, holdingId)
 		local xmlSubresult = RetrieveItemsSublist(mmsId, holdingId, offset);
 
 		if xmlSubresult == nil then
-			log:WarnFormat("No items response for MMS ID {0}, Holding ID {1} (offset {2}).", mmsId, holdingId, offset);
+			if offset == 0 then
+				log:WarnFormat("No items response for MMS ID {0}, Holding ID {1}.", mmsId, holdingId);
+			else
+				-- Mid-pagination failure: returning the items we got so far. The xmlResult's
+				-- total_record_count attribute still claims the full count, so downstream sees
+				-- a truncated list with no UI indication.
+				log:ErrorFormat("Items pagination failed for MMS ID {0}, Holding ID {1} at offset {2}; returning {3} of {4} items.",
+					mmsId, holdingId, offset, itemsNode.ChildNodes.Count, totalItems);
+			end
 			return xmlResult;
 		end
 

--- a/Catalog.lua
+++ b/Catalog.lua
@@ -128,8 +128,7 @@ function Init()
     catalogSearchForm.Form:Show();
 
     -- Initializing the AlmaApi
-    AlmaApi.ApiUrl = settings.AlmaApiUrl;
-    AlmaApi.ApiKey = settings.AlmaApiKey;
+    AlmaApi.Initialize(settings.AlmaApiUrl, settings.AlmaApiKey);
 
     -- Search when opened if autoSearch is true
     local fieldtype = GetFieldType();
@@ -297,7 +296,7 @@ function ExtractIds(itemDetails)
     local urlId = (catalogSearchForm.Browser.Address):match("%d+" .. settings.IdSuffix);
     -- Easy way to prevent duplicates regardless of order since the keys get overwritten.
     -- In rare cases the URL won't contain an ID.
-    if urlId then
+    if urlId and (urlId:find("^99") or urlId:find("^[125]1")) then
         idMatches[urlId] = true;
     end
 
@@ -330,15 +329,20 @@ function ConvertIeIdsToMmsIds(ieIds)
     for i = 1, #ieIds do
         if ieIds[i]:find("^[125]1") then
             local bibResponse = AlmaApi.RetrieveBibs(ieIds[i], "ie_id");
-            local totalRecordCount = tonumber(bibResponse:SelectSingleNode("//@total_record_count").Value);
 
-            if totalRecordCount and totalRecordCount > 0 then
-                local mmsId = bibResponse:SelectSingleNode("bibs/bib/mms_id").InnerXml;
-                log:DebugFormat("MMS ID: {0}", mmsId);
-                if mmsId then
-                    log:DebugFormat("IE ID {0} -> MMS ID {1}", ieIds[i], mmsId);
-                    -- We want to avoid duplicates here as well.
-                    resolvedIds[mmsId] = true;
+            if bibResponse == nil then
+                log:WarnFormat("No bib response for IE ID {0}. Skipping.", ieIds[i]);
+            else
+                local totalRecordCount = tonumber(bibResponse:SelectSingleNode("//@total_record_count").Value);
+
+                if totalRecordCount and totalRecordCount > 0 then
+                    local mmsId = bibResponse:SelectSingleNode("bibs/bib/mms_id").InnerXml;
+                    log:DebugFormat("MMS ID: {0}", mmsId);
+                    if mmsId then
+                        log:DebugFormat("IE ID {0} -> MMS ID {1}", ieIds[i], mmsId);
+                        -- We want to avoid duplicates here as well.
+                        resolvedIds[mmsId] = true;
+                    end
                 end
             end
         else
@@ -562,30 +566,38 @@ function RetrieveItems()
 
             local holdingsResponse = holdingsXmlDocCache[mmsIds[i]];
 
-            -- Check if it has any holdings available
-            local totalHoldingCount = tonumber(holdingsResponse:SelectSingleNode("holdings/@total_record_count").Value);
-            local suppressedNodeList = holdingsResponse:SelectNodes("holdings/holding/suppress_from_publishing[text()='true']");
-            local suppressedHoldingsCount = tonumber(suppressedNodeList.Count);
+            if holdingsResponse == nil then
+                log:WarnFormat("No holdings response for MMS ID {0}. Skipping.", mmsIds[i]);
+            else
+                -- Check if it has any holdings available
+                local totalHoldingCount = tonumber(holdingsResponse:SelectSingleNode("holdings/@total_record_count").Value);
+                local suppressedNodeList = holdingsResponse:SelectNodes("holdings/holding/suppress_from_publishing[text()='true']");
+                local suppressedHoldingsCount = tonumber(suppressedNodeList.Count);
 
-            log:DebugFormat("Records available: {0} ({1} total, {2} suppressed)", totalHoldingCount - suppressedHoldingsCount, totalHoldingCount, suppressedHoldingsCount);
+                log:DebugFormat("Records available: {0} ({1} total, {2} suppressed)", totalHoldingCount - suppressedHoldingsCount, totalHoldingCount, suppressedHoldingsCount);
 
-            -- Retrieve Item Data if Holdings are available
-            if totalHoldingCount - suppressedHoldingsCount > 0 then
-                hasHoldings = true;
-                -- Get list of the holding ids
-                local holdingIds = GetHoldingIds(holdingsResponse);
+                -- Retrieve Item Data if Holdings are available
+                if totalHoldingCount - suppressedHoldingsCount > 0 then
+                    hasHoldings = true;
+                    -- Get list of the holding ids
+                    local holdingIds = GetHoldingIds(holdingsResponse);
 
-                for _, holdingId in ipairs(holdingIds) do
-                    log:DebugFormat("Holding ID: {0}", holdingId);
-                    -- Cache the response if it hasn't been cached
-                    if (itemsXmlDocCache[holdingId] == nil ) then
-                        log:DebugFormat("Caching items for {0}", mmsIds[i]);
-                        itemsXmlDocCache[holdingId] = AlmaApi.RetrieveItemsList(mmsIds[i], holdingId);
+                    for _, holdingId in ipairs(holdingIds) do
+                        log:DebugFormat("Holding ID: {0}", holdingId);
+                        -- Cache the response if it hasn't been cached
+                        if (itemsXmlDocCache[holdingId] == nil ) then
+                            log:DebugFormat("Caching items for {0}", mmsIds[i]);
+                            itemsXmlDocCache[holdingId] = AlmaApi.RetrieveItemsList(mmsIds[i], holdingId);
+                        end
+
+                        local itemsResponse = itemsXmlDocCache[holdingId];
+
+                        if itemsResponse == nil then
+                            log:WarnFormat("No items response for Holding ID {0}. Skipping.", holdingId);
+                        else
+                            PopulateItemsDataSources(itemsResponse, itemsDataTable);
+                        end
                     end
-
-                    local itemsResponse = itemsXmlDocCache[holdingId];
-
-                    PopulateItemsDataSources(itemsResponse, itemsDataTable);
                 end
             end
         end

--- a/Config.xml
+++ b/Config.xml
@@ -2,7 +2,7 @@
 <Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>Alma Primo Definitive Catalog Search</Name>
   <Author>Atlas Systems</Author>
-  <Version>2.0.0</Version>
+  <Version>2.0.1</Version>
   <Active>True</Active>
   <Type>Addon</Type>
   <Description>Catalog Search and Import Addon that uses Alma as the catalog and Primo or Primo VE as the discovery layer.</Description>

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ## Versions
 
+**2.0.1 -** URL-based ID extraction now applies the same MMS ID (`99`) and IE ID (`[125]1`) prefix filter as the item-details scrape, preventing non-ID values in the URL's `docid` parameter from being treated as record IDs.
+
 **1.0 -** Initial release, based on original Alma Primo Catalog Search and Alma Primo VE Catalog Search addons.
 
 ## Summary

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 ## Versions
 
-**2.0.1 -** URL-based ID extraction now applies the same MMS ID (`99`) and IE ID (`[125]1`) prefix filter as the item-details scrape, preventing non-ID values in the URL's `docid` parameter from being treated as record IDs.
+**2.0.1 -**
+- URL-based ID extraction now applies the same MMS ID (`99`) and IE ID (`[125]1`) prefix filter as the item-details scrape, preventing non-ID values in the URL's `docid` parameter from being treated as record IDs.
+- Alma API key is redacted from logged URLs and exception bodies.
+- HTTP errors from Alma now surface the response status and XML error body in logs instead of being swallowed; failed API calls log and skip rather than crashing the form.
 
 **1.0 -** Initial release, based on original Alma Primo Catalog Search and Alma Primo VE Catalog Search addons.
 

--- a/WebClient.lua
+++ b/WebClient.lua
@@ -1,14 +1,53 @@
 WebClient = {};
 
+local apiKey = nil;
+
 local types = {};
 types["log4net.LogManager"] = luanet.import_type("log4net.LogManager");
 types["System.Net.WebClient"] = luanet.import_type("System.Net.WebClient");
 types["System.Text.Encoding"] = luanet.import_type("System.Text.Encoding");
 types["System.Xml.XmlTextReader"] = luanet.import_type("System.Xml.XmlTextReader");
 types["System.Xml.XmlDocument"] = luanet.import_type("System.Xml.XmlDocument");
+types["System.IO.StreamReader"] = luanet.import_type("System.IO.StreamReader");
 
 -- Create a logger
 local log = types["log4net.LogManager"].GetLogger(rootLogger .. ".AlmaApi");
+
+local function Initialize(key)
+    apiKey = key;
+end
+
+local function Redact(value)
+    if value == nil or apiKey == nil or apiKey == "" then
+        return value;
+    end
+    -- Escape any pattern-special characters so the API key is treated literally.
+    local literalPattern = apiKey:gsub("(%W)", "%%%1");
+    -- gsub returns the replacement count as a second value; the parens drop it.
+    return (tostring(value):gsub(literalPattern, "[REDACTED]"));
+end
+
+local function GetWebExceptionMessage(exception)
+    local message = "";
+
+    if exception and exception.Message then
+        message = exception.Message;
+        if (exception.InnerException) then
+            message = message .. "\r\n" .. GetWebExceptionMessage(exception.InnerException);
+
+            if exception.InnerException.Response and exception.InnerException.Response ~= "Response" then
+                -- This is necessary to get the response body from exceptions thrown by WebClients.
+                local streamReader = types["System.IO.StreamReader"](exception.InnerException.Response:GetResponseStream());
+                local responseContent = streamReader:ReadToEnd();
+                log:DebugFormat("Web exception response: {0}", Redact(responseContent));
+            end
+        end
+    elseif exception then
+        message = exception;
+    end
+
+    return message;
+end
 
 local function GetRequest(requestUrl, headers)
     local webClient = types["System.Net.WebClient"]();
@@ -18,8 +57,8 @@ local function GetRequest(requestUrl, headers)
     for _, header in ipairs(headers) do
         webClient.Headers:Add(header);
     end
-    
-    log:DebugFormat("Request URL: {0}", requestUrl);
+
+    log:DebugFormat("Request URL: {0}", Redact(requestUrl));
     local success, error = pcall(function ()
         response = webClient:DownloadString(requestUrl);
     end);
@@ -29,7 +68,7 @@ local function GetRequest(requestUrl, headers)
     if(success) then
         return response;
     else
-        log:ErrorFormat("Unable to get response from the request url: {0}", error);
+        log:ErrorFormat("Unable to get response from the request url: {0}", Redact(GetWebExceptionMessage(error)));
     end
 end
 
@@ -56,5 +95,6 @@ local function ReadResponse( responseString )
 end
 
 --Exports
+WebClient.Initialize = Initialize;
 WebClient.GetRequest = GetRequest;
 WebClient.ReadResponse = ReadResponse;

--- a/WebClient.lua
+++ b/WebClient.lua
@@ -35,11 +35,13 @@ local function GetWebExceptionMessage(exception)
         if (exception.InnerException) then
             message = message .. "\r\n" .. GetWebExceptionMessage(exception.InnerException);
 
+            -- luanet returns the literal string "Response" when this property is unbound on the exception type.
             if exception.InnerException.Response and exception.InnerException.Response ~= "Response" then
-                -- This is necessary to get the response body from exceptions thrown by WebClients.
                 local streamReader = types["System.IO.StreamReader"](exception.InnerException.Response:GetResponseStream());
                 local responseContent = streamReader:ReadToEnd();
-                log:DebugFormat("Web exception response: {0}", Redact(responseContent));
+                if responseContent and #responseContent > 0 then
+                    message = message .. "\r\nResponse body: " .. responseContent;
+                end
             end
         end
     elseif exception then


### PR DESCRIPTION
- ExtractIds: apply MMS/IE prefix filter (^99 / ^[125]1) to the URL match so non-ID values in the docid parameter are rejected.
- WebClient: add GetWebExceptionMessage helper to surface HTTP error details (status + Alma's XML error body) instead of swallowing them.
- WebClient: redact the configured Alma API key from logged URLs and exception bodies; key is set via WebClient.Initialize and hidden in a module-local.
- AlmaApi: introduce Initialize(apiUrl, apiKey) as the single setup entry point; propagates the key to WebClient.Initialize.
- Add nil-guards for failed Alma responses in ConvertIeIdsToMmsIds, RetrieveItems, and RetrieveItemsList so a failed call logs and skips instead of crashing the form.